### PR TITLE
Properly parse unicode const chars

### DIFF
--- a/pfp/interp.py
+++ b/pfp/interp.py
@@ -1324,7 +1324,7 @@ class PfpInterp(object):
 			"double": (float, fields.Double),
 
 			# cut out the quotes
-			"char": (lambda x: ord(x[1:-1].decode('unicode_escape')), fields.Char),
+			"char": (lambda x: ord(utils.string_escape(x[1:-1])), fields.Char),
 
 			# TODO should this be unicode?? will probably bite me later...
 			# cut out the quotes

--- a/pfp/interp.py
+++ b/pfp/interp.py
@@ -1324,7 +1324,7 @@ class PfpInterp(object):
 			"double": (float, fields.Double),
 
 			# cut out the quotes
-			"char": (lambda x: ord(x[1:-1]), fields.Char),
+			"char": (lambda x: ord(x[1:-1].decode('unicode_escape')), fields.Char),
 
 			# TODO should this be unicode?? will probably bite me later...
 			# cut out the quotes

--- a/tests/test_strings.py
+++ b/tests/test_strings.py
@@ -23,7 +23,19 @@ class TestStrings(unittest.TestCase, utils.UtilsMixin):
 	
 	def tearDown(self):
 		pass
-	
+
+	def test_unicode_const(self):
+		dom = self._test_parse_build(
+			"\n",
+			"""
+                        char newline;
+                        if(newline == \'\\n\') {
+                           Warning("Found newline!");
+                        }
+                        """
+                        )
+		self.assertEqual(dom.newline, ord('\n'))
+
 	def test_basic_string(self):
 		dom = self._test_parse_build(
 			"hello there\x00good byte\x00",


### PR DESCRIPTION
Ensure that the characters are unicode escaped
prior to passing them to ord, otherwise things
might fail.
