### PR TITLE
Normalize usage of pfp.errors

### DIFF
--- a/pfp/native/compat_interface.py
+++ b/pfp/native/compat_interface.py
@@ -11,7 +11,7 @@ import sys
 
 from pfp.native import native, predefine
 import pfp.fields
-import pfp.errors
+import pfp.errors as errors
 
 # http://www.sweetscape.com/010editor/manual/FuncInterface.htm
 
@@ -109,7 +109,7 @@ def Exit(params, ctxt, scope, stream, coord):
 	if len(params) != 1:
 		raise errors.InvalidArguments(coord, "1 arguments", "{} args".format(len(params)))
 	error_code = PYVAL(params[0])
-	raise pfp.errors.InterpExit(error_code)
+	raise errors.InterpExit(error_code)
 
 #void ExpandAll()
 @native(name="ExpandAll", ret=pfp.fields.Void)
@@ -738,7 +738,7 @@ def StatusMessage(params, ctxt, scope, stream, coord):
 #void Terminate( int force=true )
 @native(name="Terminate", ret=pfp.fields.Void)
 def Terminate(params, ctxt, scope, stream, coord):
-	raise pfp.errors.InterpExit()
+	raise errors.InterpExit()
 
 #void Warning( const char format[] [, argument, ... ] )
 @native(name="Warning", ret=pfp.fields.Void)

--- a/pfp/native/compat_tools.py
+++ b/pfp/native/compat_tools.py
@@ -14,6 +14,7 @@ import sys
 from pfp.native import native, predefine
 import pfp.errors as errors
 import pfp.fields
+import zlib
 
 # http://www.sweetscape.com/010editor/manual/FuncTools.htm
 
@@ -86,7 +87,7 @@ def Checksum(params, ctxt, scope, stream, coord):
 		11: "CHECKSUM_CRC16",
 		12: "CHECKSUM_CRCCCITT",
 		13: _crc32,
-		14: "CHECKSUM_ADLER32"
+		14: _checksum_Adler32
 	}
 
 	if len(params) < 1:
@@ -128,6 +129,9 @@ def Checksum(params, ctxt, scope, stream, coord):
 		# yes, this does execute even though a return statement
 		# exists within the try
 		stream.seek(stream_pos, 0)
+
+def _checksum_Adler32(data, crc_init=-1, crc_poly=-1):
+	return zlib.adler32(data)
 
 def _crc32(data, crc_init=-1, crc_poly=-1):
 	if crc_init == -1:

--- a/pfp/native/packers.py
+++ b/pfp/native/packers.py
@@ -8,6 +8,7 @@ from pfp.native import native
 import pfp.fields
 from pfp.dbg import PfpDbg
 import pfp.utils as utils
+import pfp.errors as errors
 
 @native(name="PackerGZip", ret=pfp.fields.Array)
 def packer_gzip(params, ctxt, scope, stream, coord):

--- a/pfp/native/watchers.py
+++ b/pfp/native/watchers.py
@@ -9,6 +9,7 @@ from pfp.native import native
 import pfp.fields
 from pfp.dbg import PfpDbg
 import pfp.utils as utils
+import pfp.errors as errors
 
 @native(name="WatchLength", ret=pfp.fields.Void)
 def watch_length(params, ctxt, scope, stream, coord):

--- a/tests/test_compat_checksums.py
+++ b/tests/test_compat_checksums.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+import unittest
+import os
+import sys
+import utils
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+class TestCompat(unittest.TestCase, utils.UtilsMixin):
+	def setUp(self):
+		pass
+
+	def tearDown(self):
+		pass
+
+	def test_adler32(self):
+		dom = self._test_parse_build(
+			"test\x00",
+			"""
+				string test;
+				Printf("%X", Checksum(CHECKSUM_ADLER32, 0, 1, -1, -1));
+			""",
+			stdout="750075",
+			# Required for CHECKSUM_ADLER32 to be found
+			predefines=True
+		)


### PR DESCRIPTION
There is one left over instance where `pfp.errors` is being called directly opposed to what appears to normally being used, which is an `import as`.
Also two more files where not correctly importing the errors class and would actually error on attempting to throw the error.
