### PR TITLE
Ensure 'Strings' are properly initialized.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ docs/build
 docs/source/generated
 *.pyc
 .*.sw*
+*~

--- a/pfp/fields.py
+++ b/pfp/fields.py
@@ -1625,7 +1625,7 @@ class String(Field):
 	terminator = utils.binary("\x00")
 
 	def __init__(self, stream=None, metadata_processor=None):
-		self._pfp__value = ""
+		self._pfp__value = utils.binary("")
 
 		super(String, self).__init__(stream=stream, metadata_processor=metadata_processor)
 
@@ -1705,7 +1705,7 @@ class String(Field):
 
 		"""
 		res_field = String()
-		res = ""
+		res = utils.binary("")
 		if isinstance(other, String):
 			res = self._pfp__value + other._pfp__value
 		else:

--- a/tests/test_strings.py
+++ b/tests/test_strings.py
@@ -106,5 +106,38 @@ class TestStrings(unittest.TestCase, utils.UtilsMixin):
 			stdout="Rar!\x1a\x07"
 		)
 
+	# temp_char ends up being of class Bytes in python 3 - but not on python 2
+	# This test ensures we can handle adding both a String and byte together
+	def test_add_strings(self):
+		dom = self._test_parse_build(
+			"\x01\x02\x03\x04\x05",
+			"""
+	                         local string temp_expected, temp_char;
+	                         local int i;
+	                         for(i = 0; i < 5; i++) {
+	                             SPrintf(temp_char, "%.2X", ReadUByte(FTell()+i));
+	                             temp_expected += temp_char;
+	                         }
+	                         Printf("%s", temp_expected);
+	                 """,
+			stdout="0102030405",
+			verify=False
+		)
+
+	def test_add_strings_simple(self):
+		dom = self._test_parse_build(
+			"\x01",
+			"""
+	                         local string test;
+                                 local int i;
+                                 for(i = 0; i < 5; i++) {
+                                     test += "test";
+                                 }
+                                 Printf("%s", test);
+                         """,
+			stdout="testtesttesttesttest",
+			verify=False
+		 )
+
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
Strings where not utilizing the util method to
ensure py2/3 objects would be sane. This was
causing attempts at adding str and Bytes classes
which will fail.
