### PR TITLE
Fix the some bugs see detail …

### DIFF
--- a/pfp/interp.py
+++ b/pfp/interp.py
@@ -1637,7 +1637,7 @@ class PfpInterp(object):
             "!":        lambda x,v: not x,
             "-":        lambda x,v: -x,
             "sizeof":    lambda x,v: (fields.UInt64()+x._pfp__width()),
-            "startof":    lambda x,v: x._pfp__offset,
+            "startof":    lambda x,v: (fields.UInt64()+x._pfp__offset),
         }
 
         if node.op not in switch and node.op not in special_switch:
@@ -1648,7 +1648,7 @@ class PfpInterp(object):
 
         field = self._handle_node(node.expr, scope, ctxt, stream)
         res = switch[node.op](field, 1)
-        if res in [True, False]:
+        if type(res) is bool:
             new_res = field.__class__()
             new_res._pfp__set_value(1 if res == True else 0)
             res = new_res

--- a/pfp/interp.py
+++ b/pfp/interp.py
@@ -1647,6 +1647,8 @@ class PfpInterp(object):
             return special_switch[node.op](node, scope, ctxt, stream)
 
         field = self._handle_node(node.expr, scope, ctxt, stream)
+        if type(field) is type:
+            field = field()
         res = switch[node.op](field, 1)
         if type(res) is bool:
             new_res = field.__class__()

--- a/pfp/interp.py
+++ b/pfp/interp.py
@@ -2362,8 +2362,11 @@ class PfpInterp(object):
             names = copy.copy(names)
             names.pop()
             names += resolved_names
-
-        res = switch[names[-1]]
+        
+        if len(names) >= 2 and names[-1] == names[-2] and names[-1] == "long":
+            res = "Int64"
+        else:        
+            res = switch[names[-1]]
 
         if names[-1] in ["char", "short", "int", "long"] and "unsigned" in names[:-1]:
             res = "U" + res


### PR DESCRIPTION
bug1
-------------------------
sample bt file:
````cpp
unsigned long long Test; //QWORD is the same
````

output:
0000 struct {
    0000 Test       = UInt(65557 [00010015])
}

after fix:
0000 struct {
    0000 Test       = UInt64(562958543421461L [0002000200010015])
}

bug2
------------------------
sample bt file:
````cpp
typedef struct{
    DWORD x;
    DWORD y;
}STRUCT_TEST;

local ULONG uFixupOffset = startof(STRUCT_TEST) + 5;
````

bug3
------------------------
sample bt file:
````cpp
typedef struct{
    DWORD x;
    DWORD y;
}STRUCT_TEST;

local int i = sizeof(STRUCT_TEST);
````
