### PR TITLE
fixes _pfp__path of array items

### DIFF
--- a/pfp/fields.py
+++ b/pfp/fields.py
@@ -832,7 +832,7 @@ class Struct(Field):
         modified_watchers = []
         for x in six.moves.range(len(self._pfp__children)):
             modified_watchers += self._pfp__children[x]._pfp__set_value(value[x])
-        return modified_watches
+        return modified_watchers
 
     def _pfp__add_child(self, name, child, stream=None, overwrite=False):
         """Add a child to the Struct field. If multiple consecutive fields are

--- a/pfp/fields.py
+++ b/pfp/fields.py
@@ -2098,13 +2098,14 @@ class Array(Field):
     def __init__(self, width, field_cls, stream=None, metadata_processor=None):
         """ Create an array field of size "width" from the stream
         """
+        self.items = []
+
         super(Array, self).__init__(
             stream=None, metadata_processor=metadata_processor
         )
 
         self.width = width
         self.field_cls = field_cls
-        self.items = []
         self.raw_data = None
         self.implicit = False
 
@@ -2140,6 +2141,7 @@ class Array(Field):
     def append(self, item):
         # TODO check for consistent type
         item._pfp__parent = self
+        item._pfp__name = "{}[{}]".format(self._pfp__name, self.width)
         self.items.append(item)
         self.width = len(self.items)
 
@@ -2254,7 +2256,6 @@ class Array(Field):
             self.items = []
             for x in six.moves.range(PYVAL(self.width)):
                 field = self.field_cls(stream)
-                field._pfp__name = "{}[{}]".format(self._pfp__name, x)
                 self.append(field)
 
             if self._pfp__can_unpack():
@@ -2336,6 +2337,13 @@ class Array(Field):
             self[idx]._pfp__set_value(value)
 
         self._pfp__notify_update(self)
+
+    def __setattr__(self, name, value):
+        super(Array, self).__setattr__(name, value)
+
+        if name == "_pfp__name":
+            for idx, item in enumerate(self.items):
+                item._pfp__name = "{}[{}]".format(self._pfp__name, idx)
 
     def __repr__(self):
         other = ""

--- a/pfp/fields.py
+++ b/pfp/fields.py
@@ -2211,17 +2211,21 @@ class Array(Field):
         #        len(value)
         #    ))
 
-        if len(value) > len(self.items):
-            self.items.extend([None] * (len(value) - len(self.items)))
-
-        for idx, item in enumerate(value):
+        new_items = []
+        for item in value:
             if not isinstance(item, Field):
                 new_item = self.field_cls()
                 new_item._pfp__set_value(item)
                 item = new_item
-            self.items[idx] = item
+            new_items.append(item)
 
-        self.width = len(self.items)
+        if len(new_items) < len(self.items):
+            new_items += self.items[len(new_items):]
+
+        self.items = []
+        self.width = 0
+        for item in new_items:
+            self.append(item)
 
         # see #54 - make sure raw_data is set to None if overwriting with
         # a new array/list/set/tuple

--- a/pfp/fields.py
+++ b/pfp/fields.py
@@ -2115,7 +2115,7 @@ class Array(Field):
         else:
             if width is not None:
                 for x in six.moves.range(self.width):
-                    self.items.append(self.field_cls())
+                    self.append(self.field_cls())
 
     def _pfp__snapshot(self, recurse=True):
         """Save off the current value of the field
@@ -2251,8 +2251,7 @@ class Array(Field):
             for x in six.moves.range(PYVAL(self.width)):
                 field = self.field_cls(stream)
                 field._pfp__name = "{}[{}]".format(self._pfp__name, x)
-                # field._pfp__parse(stream, save_offset)
-                self.items.append(field)
+                self.append(field)
 
             if self._pfp__can_unpack():
                 curr_offset = stream.tell()

--- a/tests/test_arrays.py
+++ b/tests/test_arrays.py
@@ -334,6 +334,27 @@ class TestArrays(utils.PfpTestCase):
             stdout="00|00|00|00|",
         )
 
+    def test_parent_is_set_for_array_items(self):
+        dom = self._test_parse_build(
+            "\x00\x00\x11\x11\x22\x22",
+            """
+                typedef struct _struct_type {
+                    char x;
+                    char y;
+                } struct_type;
+
+                struct_type the_array[3];
+            """
+        )
+
+        self.assertIs(dom.the_array[0]._pfp__parent, dom.the_array)
+        self.assertIs(dom.the_array[1]._pfp__parent, dom.the_array)
+        self.assertIs(dom.the_array[2]._pfp__parent, dom.the_array)
+
+        adhoc_array = Array(3, dom.the_array.field_cls)
+        self.assertIs(adhoc_array[0]._pfp__parent, adhoc_array)
+        self.assertIs(adhoc_array[1]._pfp__parent, adhoc_array)
+        self.assertIs(adhoc_array[2]._pfp__parent, adhoc_array)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_arrays.py
+++ b/tests/test_arrays.py
@@ -399,6 +399,23 @@ class TestArrays(utils.PfpTestCase):
         self.assertEqual(adhoc_array[1].x._pfp__path(), "new_name[1].x")
         self.assertEqual(adhoc_array[1].y._pfp__path(), "new_name[1].y")
 
+    def test_path_for_inserted_array_item(self):
+        dom = self._test_parse_build(
+            "\x00\x00\x11\x11\x22\x22",
+            """
+                typedef struct _two_chars {
+                    char x;
+                    char y;
+                } two_chars;
+
+                two_chars the_array[3];
+            """
+        )
+
+        dom.the_array[1] = dom.the_array.field_cls()
+        self.assertEqual(dom.the_array[1]._pfp__path(), "the_array[1]")
+        self.assertEqual(dom.the_array[1].x._pfp__path(), "the_array[1].x")
+        self.assertEqual(dom.the_array[1].y._pfp__path(), "the_array[1].y")
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_arrays.py
+++ b/tests/test_arrays.py
@@ -374,5 +374,31 @@ class TestArrays(utils.PfpTestCase):
         self.assertIs(dom.the_array[1]._pfp__parent, dom.the_array)
         self.assertIs(dom.the_array[2]._pfp__parent, dom.the_array)
 
+    def test_path_for_array_items(self):
+        dom = self._test_parse_build(
+            "\x00\x00\x11\x11\x22\x22",
+            """
+                typedef struct _two_chars {
+                    char x;
+                    char y;
+                } two_chars;
+
+                struct {
+                    two_chars the_array[3];
+                } container;
+            """
+        )
+
+        self.assertEqual(dom.container.the_array[1]._pfp__path(), "container.the_array[1]")
+        self.assertEqual(dom.container.the_array[1].x._pfp__path(), "container.the_array[1].x")
+        self.assertEqual(dom.container.the_array[1].y._pfp__path(), "container.the_array[1].y")
+
+        adhoc_array = Array(3, dom.container.the_array.field_cls)
+        adhoc_array._pfp__name = "new_name"
+        self.assertEqual(adhoc_array[1]._pfp__path(), "new_name[1]")
+        self.assertEqual(adhoc_array[1].x._pfp__path(), "new_name[1].x")
+        self.assertEqual(adhoc_array[1].y._pfp__path(), "new_name[1].y")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_arrays.py
+++ b/tests/test_arrays.py
@@ -356,5 +356,23 @@ class TestArrays(utils.PfpTestCase):
         self.assertIs(adhoc_array[1]._pfp__parent, adhoc_array)
         self.assertIs(adhoc_array[2]._pfp__parent, adhoc_array)
 
+    def test_parent_of_items_is_set_when_changing_value(self):
+        dom = self._test_parse_build(
+            "\x00\x00\x11\x11\x22\x22",
+            """
+                typedef struct _struct_type {
+                    char x;
+                    char y;
+                } struct_type;
+
+                struct_type the_array[3];
+            """
+        )
+
+        dom.the_array._pfp__set_value([[1, 1], [2, 2], [3, 3]])
+        self.assertIs(dom.the_array[0]._pfp__parent, dom.the_array)
+        self.assertIs(dom.the_array[1]._pfp__parent, dom.the_array)
+        self.assertIs(dom.the_array[2]._pfp__parent, dom.the_array)
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_struct_union.py
+++ b/tests/test_struct_union.py
@@ -459,9 +459,9 @@ class TestStructUnion(utils.PfpTestCase):
             """,
         )
         chars = [x for x in dom.bytes]
-        self.assertEquals(chars[0], 0x41)
-        self.assertEquals(chars[1], 0x42)
-        self.assertEquals(chars[2], 0x43)
+        self.assertEqual(chars[0], 0x41)
+        self.assertEqual(chars[1], 0x42)
+        self.assertEqual(chars[2], 0x43)
 
     def test_struct_set_value(self):
         dom = self._test_parse_build(

--- a/tests/test_struct_union.py
+++ b/tests/test_struct_union.py
@@ -10,7 +10,6 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 import pfp
 import pfp.fields
 import pfp.interp
-import pfp.utils
 
 import utils
 
@@ -146,7 +145,7 @@ class TestStructUnion(utils.PfpTestCase):
         self.assertEqual(dom.root.nested1.nested2.array[3]._pfp__path(), "root.nested1.nested2.array[3]")
     
     def test_struct(self):
-        dom = self._test_parse_build(
+        self._test_parse_build(
             "abcddcba",
             """
                 typedef struct {
@@ -159,7 +158,7 @@ class TestStructUnion(utils.PfpTestCase):
         )
     
     def test_forward_declared_struct(self):
-        dom = self._test_parse_build(
+        self._test_parse_build(
             "\x00\x01",
             """
                 struct fp16;
@@ -302,7 +301,7 @@ class TestStructUnion(utils.PfpTestCase):
     #        )
 
     def test_union(self):
-        dom = self._test_parse_build(
+        self._test_parse_build(
             "abcd",
             """
                 typedef union {
@@ -410,7 +409,7 @@ class TestStructUnion(utils.PfpTestCase):
         # the problem is that the script still needs to be able to access
         # the last declared field by the original name and not the
         # suffixed one.
-        dom = self._test_parse_build(
+        self._test_parse_build(
             "\x01a\x01b\x01c",
             """
                 while(!FEof()) {
@@ -425,7 +424,7 @@ class TestStructUnion(utils.PfpTestCase):
     def test_implicit_array_dot_notation_for_last(self):
         # I BELIEVE scripts are able to access implicit array items
         # by index OR directly access the last one without an index
-        dom = self._test_parse_build(
+        self._test_parse_build(
             "\x01a\x01b\x01c",
             """
                 typedef struct {

--- a/tests/test_struct_union.py
+++ b/tests/test_struct_union.py
@@ -463,6 +463,25 @@ class TestStructUnion(utils.PfpTestCase):
         self.assertEquals(chars[1], 0x42)
         self.assertEquals(chars[2], 0x43)
 
+    def test_struct_set_value(self):
+        dom = self._test_parse_build(
+            "abc",
+            """
+                typedef struct {
+                    char first;
+                    char second;
+                    char third;
+                } three_bytes;
+
+                three_bytes bytes;
+            """,
+        )
+
+        dom.bytes._pfp__set_value([ord("x"), ord("y"), ord("z")])
+        self.assertEqual(dom.bytes.first, ord("x"))
+        self.assertEqual(dom.bytes.second, ord("y"))
+        self.assertEqual(dom.bytes.third, ord("z"))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This fixes #144 by making sure that the item's parent is properly set and that the item's name is being recomputed when the array changes name.